### PR TITLE
Extended the client config

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Modify your `playwright.config.ts` file to include the following:
   ],
 ```
 
-Run your tests by providing your` SLACK_BOT_USER_OAUTH_TOKEN` as an environment variable:
+Run your tests by providing your `SLACK_BOT_USER_OAUTH_TOKEN` as an environment variable or specifying `slackOAuthToken` option in the config:
 
 `SLACK_BOT_USER_OAUTH_TOKEN=[your Slack bot user OAUTH token] npx playwright test`
 
@@ -102,7 +102,7 @@ An example advanced configuration is shown below:
 
 ```typescript
   import { generateCustomLayout } from "./my_custom_layout";
-
+  import { LogLevel } from '@slack/web-api';
   ...
 
   reporter: [
@@ -127,6 +127,8 @@ An example advanced configuration is shown below:
                 value: '<https://your-build-artifacts.my.company.dev/pw/23887/playwright-report/index.html|📊>',
             },
         ],
+        slackOAuthToken: 'YOUR_SLACK_OAUTH_TOKEN',
+        slackLogLevel: LogLevel.DEBUG
       },
 
     ],
@@ -147,6 +149,11 @@ A function that returns a layout object, this configuration is optional.  See se
 Same as **layout** above, but asynchronous in that it returns a promise.
 ### **maxNumberOfFailuresToShow**
 Limits the number of failures shown in the Slack message, defaults to 10.
+### **slackOAuthToken**
+Instead of providing an environment variable `SLACK_BOT_USER_OAUTH_TOKEN` you can specify the token in the config in the `slackOAuthToken` field.
+### **slackLogLevel** (default LogLevel.DEBUG)
+This option allows you to control slack client severity levels for log entries. It accepts a value from @slack/web-api `LogLevel` enum
+
 
 **Examples:**
 ```typescript

--- a/src/SlackClient.ts
+++ b/src/SlackClient.ts
@@ -7,6 +7,7 @@ import {
   KnownBlock,
   Block,
   ChatPostMessageResponse,
+  LogLevel,
 } from '@slack/web-api';
 import { SummaryResults } from '.';
 import generateBlocks from './LayoutGenerator';
@@ -25,11 +26,13 @@ export default class SlackClient {
   }: {
     options: {
       channelIds: Array<string>;
-      summaryResults: SummaryResults;
       customLayout: Function | undefined;
       customLayoutAsync: Function | undefined;
       fakeRequest?: Function;
       maxNumberOfFailures: number;
+      slackOAuthToken?: string;
+      slackLogLevel?: LogLevel;
+      summaryResults: SummaryResults;
     };
   }): Promise<Array<{ channel: string; outcome: string }>> {
     let blocks: (Block | KnownBlock)[];

--- a/tests/SlackReporter.spec.ts
+++ b/tests/SlackReporter.spec.ts
@@ -152,7 +152,7 @@ test.describe('SlackReporter - onEnd()', () => {
     await fakeSlackReporter.onEnd();
     expect(
       fakeSlackReporter.logs.includes(
-        '❌ SLACK_BOT_USER_OAUTH_TOKEN was not found',
+        '❌ Neither slackOAuthToken nor process.env.SLACK_BOT_USER_OAUTH_TOKEN were found',
       ),
     ).toBeTruthy();
   });
@@ -192,7 +192,7 @@ test.describe('SlackReporter - preChecks()', () => {
     const result = fakeSlackReporter.preChecks();
     expect(result).toEqual({
       okToProceed: false,
-      message: '❌ SLACK_BOT_USER_OAUTH_TOKEN was not found',
+      message: '❌ Neither slackOAuthToken nor process.env.SLACK_BOT_USER_OAUTH_TOKEN were found',
     });
   });
 


### PR DESCRIPTION
In that PR I've added 2 options in the config.

1. slackOAuthToken. It allows you to specify slackOAuth token if for any reason you want to use a different variable name and/or form .env file.

2. slackLogLevel. It allows you to change the log level for the slack client. Currently, it's hardcoded to 'DEBUG'