### PR TITLE
Add function to retrieve nested project settings

### DIFF
--- a/src/ResultsParser.ts
+++ b/src/ResultsParser.ts
@@ -102,19 +102,14 @@ export default class ResultsParser {
 
   addTestResult(suiteName: any, testCase: any) {
     const testResults: testResult[] = [];
+    const projectSettings = this.getParentConfigInformation(testCase);
     for (const result of testCase.results) {
       testResults.push({
         suiteName,
         name: testCase.title,
         status: result.status,
-        // eslint-disable-next-line no-underscore-dangle
-        browser: testCase.parent?.parent?._projectConfig?.use?.defaultBrowserType
-          ? testCase.parent.parent._projectConfig.use.defaultBrowserType
-          : '',
-        // eslint-disable-next-line no-underscore-dangle
-        projectName: testCase.parent?.parent?._projectConfig?.name
-          ? testCase.parent.parent._projectConfig.name
-          : '',
+        browser: projectSettings.browser,
+        projectName: projectSettings.projectName,
         retry: result.retry,
         retries: testCase.retries,
         startedAt: new Date(result.startTime).toISOString(),
@@ -170,5 +165,17 @@ export default class ResultsParser {
         '',
       );
     return logsStripped;
+  }
+
+  getParentConfigInformation(testCase: any): {projectName: string, browser: string} {
+    if (testCase._projectConfig !== undefined) {
+      return {
+        projectName: testCase._projectConfig.name || '',
+        browser: testCase._projectConfig.use?.defaultBrowserType || '',
+      };
+    } if (testCase.parent) {
+      return this.getParentConfigInformation(testCase.parent);
+    }
+    return { projectName: '', browser: '' };
   }
 }


### PR DESCRIPTION
I was running into an issue where we had tests nested within describe blocks and the reporter was unable to retrieve the project settings due to the hardcoded parent paths present. 

Added a function that takes in the `testCase` object and recursively looks through it to retrieve the project name and browser, defaults to empty strings if it reaches the end of the parent chain was unable to find the `_projectConfig` property. 