### PR TITLE
Adding unfurlEnable option in order to be able to disable unfurl

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ Run the tests using `npm run pw`
 Run `npm pack`
 
 Create a new playwright project using `yarn create playwright`
-Modify the `package.json` and a local dependancy to the generated `tgz` file
+Modify the `package.json` and a local dependency to the generated `tgz` file
 
 e.g.
 

--- a/src/SlackClient.ts
+++ b/src/SlackClient.ts
@@ -86,7 +86,6 @@ export default class SlackClient {
       channel,
       text: ' ',
       unfurl_link: unfurl,
-      unfurl_media: unfurl,
       blocks,
     });
     return chatResponse;

--- a/src/SlackClient.ts
+++ b/src/SlackClient.ts
@@ -32,6 +32,7 @@ export default class SlackClient {
       maxNumberOfFailures: number;
       slackOAuthToken?: string;
       slackLogLevel?: LogLevel;
+      unfurlEnable?: boolean;
       summaryResults: SummaryResults;
     };
   }): Promise<Array<{ channel: string; outcome: string }>> {
@@ -48,6 +49,7 @@ export default class SlackClient {
     }
 
     const result = [];
+    const unfurl: boolean = options.unfurlEnable;
     for (const channel of options.channelIds) {
       let chatResponse: ChatPostMessageResponse;
       try {
@@ -56,7 +58,7 @@ export default class SlackClient {
           chatResponse = await options.fakeRequest();
         } else {
           // send request for reals
-          chatResponse = await this.doPostRequest(channel, blocks);
+          chatResponse = await this.doPostRequest(channel, blocks, unfurl);
         }
         if (chatResponse.ok) {
           result.push({ channel, outcome: `✅ Message sent to ${channel}` });
@@ -78,10 +80,13 @@ export default class SlackClient {
   async doPostRequest(
     channel: string,
     blocks: Array<KnownBlock | Block>,
+    unfurl: boolean,
   ): Promise<ChatPostMessageResponse> {
     const chatResponse = await this.slackWebClient.chat.postMessage({
       channel,
       text: ' ',
+      unfurl_link: unfurl,
+      unfurl_media: unfurl,
       blocks,
     });
     return chatResponse;

--- a/src/SlackReporter.ts
+++ b/src/SlackReporter.ts
@@ -27,6 +27,8 @@ class SlackReporter implements Reporter {
 
   private slackOAuthToken: string | undefined;
 
+  private enableUnfurl: boolean | undefined;
+
   private suite!: Suite;
 
   logs: string[] = [];
@@ -44,6 +46,7 @@ class SlackReporter implements Reporter {
       this.slackChannels = slackReporterConfig.channels;
       this.maxNumberOfFailuresToShow = slackReporterConfig.maxNumberOfFailuresToShow || 10;
       this.slackOAuthToken = slackReporterConfig.slackOAuthToken || undefined;
+      this.enableUnfurl = slackReporterConfig.enableUnfurl || true;
     }
     this.resultsParser = new ResultsParser();
   }
@@ -82,6 +85,7 @@ class SlackReporter implements Reporter {
         customLayout: this.customLayout,
         customLayoutAsync: this.customLayoutAsync,
         maxNumberOfFailures: this.maxNumberOfFailuresToShow,
+        unfurlEnable: this.enableUnfurl,
         summaryResults: resultSummary,
       },
     });


### PR DESCRIPTION
If we send messages with URLs (e.g. the reporting URL), slack will unfurl that URL by default. The Slack API allows us to disable the automatic unfurl by using the `unfurl_link` parameter as follows.

- `unfurl_link: false`

You can find more details under:
- https://api.slack.com/reference/messaging/link-unfurling

@ryanrosello-og would u mind taking a look?