### PR TITLE
Updated logic for unfurl

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ An example advanced configuration is shown below:
         ],
         slackOAuthToken: 'YOUR_SLACK_OAUTH_TOKEN',
         slackLogLevel: LogLevel.DEBUG,
-        enableUnfurl: false,
+        disableUnfurl: true,
         showInThread: true,
       },
 
@@ -155,7 +155,7 @@ Limits the number of failures shown in the Slack message, defaults to 10.
 Instead of providing an environment variable `SLACK_BOT_USER_OAUTH_TOKEN` you can specify the token in the config in the `slackOAuthToken` field.
 ### **slackLogLevel** (default LogLevel.DEBUG)
 This option allows you to control slack client severity levels for log entries. It accepts a value from @slack/web-api `LogLevel` enum
-### **enableUnfurl** (default: true)
+### **disableUnfurl** (default: true)
 Enable or disable unfurling of links in Slack messages.
 ### **showInThread** (default: false)
 Instructs the reporter to show the failure details in a thread instead of the main channel.

--- a/src/SlackClient.ts
+++ b/src/SlackClient.ts
@@ -32,7 +32,7 @@ export default class SlackClient {
       maxNumberOfFailures: number;
       slackOAuthToken?: string;
       slackLogLevel?: LogLevel;
-      unfurlEnable?: boolean;
+      disableUnfurl?: boolean;
       summaryResults: SummaryResults;
       showInThread: boolean;
     };
@@ -60,7 +60,7 @@ export default class SlackClient {
     }
 
     const result = [];
-    const unfurl: boolean = options.unfurlEnable;
+    const unfurl: boolean = options.disableUnfurl ? false : true;
     for (const channel of options.channelIds) {
       let chatResponse: ChatPostMessageResponse;
       try {
@@ -109,14 +109,14 @@ export default class SlackClient {
     ts,
     summaryResults,
     maxNumberOfFailures,
-    unfurlEnable,
+    disableUnfurl: disableUnfurl,
     fakeRequest,
   }: {
     channelIds: Array<string>;
     ts: string;
     summaryResults: SummaryResults;
     maxNumberOfFailures: number;
-    unfurlEnable?: boolean;
+    disableUnfurl?: boolean;
     fakeRequest?: Function;
   }) {
     const result = [];
@@ -131,7 +131,7 @@ export default class SlackClient {
           this.slackWebClient,
           channel,
           blocks,
-          unfurlEnable,
+          disableUnfurl,
           ts,
         );
       }

--- a/src/SlackReporter.ts
+++ b/src/SlackReporter.ts
@@ -33,7 +33,7 @@ class SlackReporter implements Reporter {
 
   private slackOAuthToken: string | undefined;
 
-  private enableUnfurl: boolean | undefined;
+  private disableUnfurl: boolean | undefined;
 
   private suite!: Suite;
 
@@ -52,7 +52,7 @@ class SlackReporter implements Reporter {
       this.slackChannels = slackReporterConfig.channels;
       this.maxNumberOfFailuresToShow = slackReporterConfig.maxNumberOfFailuresToShow || 10;
       this.slackOAuthToken = slackReporterConfig.slackOAuthToken || undefined;
-      this.enableUnfurl = slackReporterConfig.enableUnfurl || true;
+      this.disableUnfurl = slackReporterConfig.disableUnfurl || false;
       this.showInThread = slackReporterConfig.showInThread || false;
     }
     this.resultsParser = new ResultsParser();
@@ -98,7 +98,7 @@ class SlackReporter implements Reporter {
         customLayout: this.customLayout,
         customLayoutAsync: this.customLayoutAsync,
         maxNumberOfFailures: this.maxNumberOfFailuresToShow,
-        unfurlEnable: this.enableUnfurl,
+        disableUnfurl: this.disableUnfurl,
         summaryResults: resultSummary,
         showInThread: this.showInThread,
       },


### PR DESCRIPTION
The current implementation for the unfurl is not working as expected. Unfortunately, I was having some trouble testing my code before merging, and sorry about that. With the current code, the unfurl is always set to True because of the dummy line as follows:

`this.enableUnfurl = slackReporterConfig.enableUnfurl || true`

Moved the logic to use disableUnfurl instead and hopefully that will fix the issue.