### PR TITLE
fix issues with for blank browser info in the summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint": "npx eslint . --ext .ts"
   },
   "name": "playwright-slack-report",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "main": "index.js",
   "types": "dist/index.d.ts",
   "repository": "git@github.com:ryanrosello-og/playwright-slack-report.git",

--- a/src/ResultsParser.ts
+++ b/src/ResultsParser.ts
@@ -100,9 +100,9 @@ export default class ResultsParser {
     }
   }
 
-  addTestResult(suiteName: any, testCase: any) {
+  addTestResult(suiteName: any, testCase: any, projectBrowserMapping: any) {
     const testResults: testResult[] = [];
-    const projectSettings = this.getParentConfigInformation(testCase);
+    const projectSettings = this.determineBrowser(testCase._projectId, projectBrowserMapping);
     for (const result of testCase.results) {
       testResults.push({
         suiteName,
@@ -167,19 +167,25 @@ export default class ResultsParser {
     return logsStripped;
   }
 
-  getParentConfigInformation(testCase: any): {
+  determineBrowser(
+    projectName: string,
+    browserMappings: { projectName: string; browser: string }[],
+  ): {
     projectName: string;
     browser: string;
   } {
-    if (testCase._projectConfig !== undefined) {
+    const browserMapping = browserMappings.find(
+      (mapping) => mapping.projectName === projectName,
+    );
+    if (browserMapping) {
       return {
-        projectName: testCase._projectConfig.name || '',
-        browser: testCase._projectConfig.use?.defaultBrowserType || '',
+        projectName: browserMapping.projectName,
+        browser: browserMapping.browser,
       };
     }
-    if (testCase.parent) {
-      return this.getParentConfigInformation(testCase.parent);
-    }
-    return { projectName: '', browser: '' };
+    return {
+      projectName: '',
+      browser: '',
+    };
   }
 }

--- a/src/SlackReporter.ts
+++ b/src/SlackReporter.ts
@@ -51,7 +51,7 @@ class SlackReporter implements Reporter {
       this.browsers = [];
     } else {
       // eslint-disable-next-line max-len
-      this.browsers = fullConfig.projects.map((obj) => ({ projectName: obj.name, browser: obj.use.defaultBrowserType }));
+      this.browsers = fullConfig.projects.map((obj) => ({ projectName: obj.name, browser: obj.use.browserName ? obj.use.browserName : obj.use.defaultBrowserType }));
     }
 
     if (slackReporterConfig) {

--- a/src/SlackReporter.ts
+++ b/src/SlackReporter.ts
@@ -37,6 +37,8 @@ class SlackReporter implements Reporter {
 
   private proxy: string | undefined;
 
+  private browsers: {projectName: string ; browser: string}[] = [];
+
   private suite!: Suite;
 
   logs: string[] = [];
@@ -45,6 +47,12 @@ class SlackReporter implements Reporter {
     this.suite = suite;
     this.logs = [];
     const slackReporterConfig = fullConfig.reporter.filter((f) => f[0].toLowerCase().includes('slackreporter'))[0][1];
+    if (fullConfig.projects.length === 0) {
+      this.browsers = [];
+    } else {
+      // eslint-disable-next-line max-len
+      this.browsers = fullConfig.projects.map((obj) => ({ projectName: obj.name, browser: obj.use.defaultBrowserType }));
+    }
 
     if (slackReporterConfig) {
       this.meta = slackReporterConfig.meta || [];
@@ -64,7 +72,7 @@ class SlackReporter implements Reporter {
 
   // eslint-disable-next-line class-methods-use-this, no-unused-vars
   onTestEnd(test: TestCase, result: TestResult): void {
-    this.resultsParser.addTestResult(test.parent.title, test);
+    this.resultsParser.addTestResult(test.parent.title, test, this.browsers);
   }
 
   async onEnd(): Promise<void> {

--- a/tests/ResultsParser.spec.ts
+++ b/tests/ResultsParser.spec.ts
@@ -74,6 +74,7 @@ const test = base.extend<{ testData: any }>({
                   column: 1,
                 },
                 expectedStatus: 'passed',
+                _projectId: 'playwright-slack-report',
               },
             ],
             location: {
@@ -170,11 +171,35 @@ const test = base.extend<{ testData: any }>({
 });
 
 test.describe('ResultsParser', () => {
+  test('determines correct browser based on project config', async ({
+    testData,
+  }) => {
+    const resultsParser = new ResultsParser();
+    resultsParser.addTestResult(
+      testData.suites[0].suites[0].title,
+      testData.suites[0].suites[0].tests[0],
+      [
+        {
+          projectName: 'ui',
+          browser: 'webkit',
+        },
+        {
+          projectName: 'playwright-slack-report',
+          browser: 'chrome',
+        },
+      ],
+    );
+    const results = await resultsParser.getParsedResults();
+    expect(results.tests[0].projectName).toEqual('playwright-slack-report');
+    expect(results.tests[0].browser).toEqual('chrome');
+  });
+
   test('parses results successfully', async ({ testData }) => {
     const resultsParser = new ResultsParser();
     resultsParser.addTestResult(
       testData.suites[0].suites[0].title,
       testData.suites[0].suites[0].tests[0],
+      [],
     );
     const results = await resultsParser.getParsedResults();
     expect(results).toEqual({
@@ -230,15 +255,17 @@ test.describe('ResultsParser', () => {
     });
   });
 
-  test('parses multiple faliures successfully', async ({ testData }) => {
+  test('parses multiple failures successfully', async ({ testData }) => {
     const resultsParser = new ResultsParser();
     resultsParser.addTestResult(
       testData.suites[0].suites[0].title,
       testData.suites[0].suites[0].tests[0],
+      [],
     );
     resultsParser.addTestResult(
       testData.suites[0].suites[0].title,
       testData.suites[1].suites[0].tests[0],
+      [],
     );
     const results = await resultsParser.getParsedResults();
     expect(results.failures).toEqual([


### PR DESCRIPTION
Fixes these two:

https://github.com/ryanrosello-og/playwright-slack-report/issues/25
https://github.com/ryanrosello-og/playwright-slack-report/issues/36

Note: if you playwright config does not use the project settings, both the projectName and browser will be defaulted to blank.