### PR TITLE
Fix GH actions issue when the CLI app would falls over if the Playwright config does not have retries defined.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "cli-debug": "yarn build && npx . -c ./cli_config.json -j ./tests/test_data/valid_test_results.json"
   },
   "name": "playwright-slack-report",
-  "version": "1.1.55",
+  "version": "1.1.56",
   "bin": {
     "playwright-slack-report": "dist/cli.js"
   },

--- a/src/ResultsParser.ts
+++ b/src/ResultsParser.ts
@@ -50,7 +50,7 @@ export default class ResultsParser {
     const data = fs.readFileSync(filePath, 'utf-8');
     const parsedData: JSONResult = JSON.parse(data);
 
-    const { retries } = parsedData.config.projects[0];
+    const retries = parsedData.config.projects[0]?.retries || 0;
     await this.parseTestSuite(parsedData.suites, retries);
 
     const failures = await this.getFailures();


### PR DESCRIPTION
Should address https://github.com/ryanrosello-og/playwright-slack-report/issues/75

- Fixed issue where the CLI app would falls over if the playwright config does not have retries defined.  
- Updated the README to clarify redirecting the merge output to a json file