### PR TITLE
Support separate Slack channels for notifications of successful and failed test results

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,10 @@ An example advanced configuration is shown below:
 
 ### **channels**
 An array of Slack channels to post to, at least one channel is required
+### **onSuccessChannels**
+(Optional) An array of Slack channels to post to when tests have passed. Value from `channels` is used if not defined here
+### **onFailureChannels**
+(Optional) An array of Slack channels to post to when tests have failed. Value from `channels` is used if not defined here
 ### **sendResults**
 Can either be *"always"*, *"on-failure"* or *"off"*, this configuration is required:
   * **always** - will send the results to Slack at completion of the test run

--- a/tests/SlackReporter.spec.ts
+++ b/tests/SlackReporter.spec.ts
@@ -257,7 +257,7 @@ test.describe('SlackReporter - preChecks()', () => {
     const result = fakeSlackReporter.preChecks();
     expect(result).toEqual({
       okToProceed: false,
-      message: '❌ Slack channel(s) was not provided in the config',
+      message: '❌ Slack channel(s) for successful tests notifications was not provided in the config',
     });
   });
 
@@ -292,7 +292,10 @@ test.describe('SlackReporter - preChecks()', () => {
     cloneFullConfig.reporter = [
       [
         '/home/ry/_repo/playwright-slack-report/src/SlackReporter.ts',
-        { layout: 'not a function' },
+        {
+          layout: 'not a function',
+          channels: ['zeb', 'pw'],
+        },
       ],
     ];
     fakeSlackReporter.onBegin(cloneFullConfig, suite);
@@ -313,7 +316,10 @@ test.describe('SlackReporter - preChecks()', () => {
     cloneFullConfig.reporter = [
       [
         '/home/ry/_repo/playwright-slack-report/src/SlackReporter.ts',
-        { meta: 'not a array' },
+        {
+          meta: 'not a array',
+          channels: ['zeb', 'pw'],
+        },
       ],
     ];
     fakeSlackReporter.onBegin(cloneFullConfig, suite);


### PR DESCRIPTION
This PR adds support for sending Slack notification to different channels depending on the test results (passed or failed).

Resolves issue: https://github.com/ryanrosello-og/playwright-slack-report/issues/69