### PR TITLE
fixed logic for incorrect message sent on failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "cli-debug": "yarn build && npx . -c ./cli_config.json -j ./tests/test_data/valid_test_results.json"
   },
   "name": "playwright-slack-report",
-  "version": "1.1.71",
+  "version": "1.1.72",
   "bin": {
     "playwright-slack-report": "dist/cli.js"
   },

--- a/src/SlackReporter.ts
+++ b/src/SlackReporter.ts
@@ -102,11 +102,7 @@ class SlackReporter implements Reporter {
       this.suite.allTests(),
     );
     resultSummary.meta = this.meta;
-    const maxRetry = Math.max(...resultSummary.tests.map((o) => o.retry));
-    const testsFailed = resultSummary.tests.some(
-      (z) => (z.status === 'failed' || z.status === 'timedOut')
-        && z.retry === maxRetry,
-    );
+    const testsFailed = resultSummary.failed > 0;
 
     if (this.sendResults === 'on-failure' && !testsFailed) {
       this.log('⏩ Slack reporter - no failures found');


### PR DESCRIPTION
Fix for https://github.com/ryanrosello-og/playwright-slack-report/issues/93