### PR TITLE
Bug/maxnumberoffailures does not work when set to zero

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "cli-debug": "yarn build && npx . -c ./cli_config.json -j ./tests/test_data/valid_test_results.json"
   },
   "name": "playwright-slack-report",
-  "version": "1.1.72",
+  "version": "1.1.73",
   "bin": {
     "playwright-slack-report": "dist/cli.js"
   },

--- a/src/SlackReporter.ts
+++ b/src/SlackReporter.ts
@@ -75,7 +75,9 @@ class SlackReporter implements Reporter {
       this.onFailureSlackChannels
         = slackReporterConfig.onFailureChannels || slackReporterConfig.channels;
       this.maxNumberOfFailuresToShow
-        = slackReporterConfig.maxNumberOfFailuresToShow || 10;
+        = slackReporterConfig.maxNumberOfFailuresToShow !== undefined
+          ? slackReporterConfig.maxNumberOfFailuresToShow
+          : 10;
       this.slackOAuthToken = slackReporterConfig.slackOAuthToken || undefined;
       this.slackWebHookUrl = slackReporterConfig.slackWebHookUrl || undefined;
       this.disableUnfurl = slackReporterConfig.disableUnfurl || false;


### PR DESCRIPTION
**Description:**
Fix `maxNumberOfFailuresToShow` defaulting to 10, when the value in the config is set to zero


**Related issue:**
[maxNumberOfFailuresToShow doesn't seem to work as expected](https://github.com/ryanrosello-og/playwright-slack-report/issues/125)

