### PR TITLE
Feature/issues/137/suppress reporting when no tests run

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "cli-debug": "yarn build && npx . -c ./cli_config.json -j ./tests/test_data/valid_test_results.json"
   },
   "name": "playwright-slack-report",
-  "version": "1.1.80",
+  "version": "1.1.81",
   "bin": {
     "playwright-slack-report": "dist/cli.js"
   },

--- a/src/ResultsParser.ts
+++ b/src/ResultsParser.ts
@@ -47,8 +47,16 @@ export default class ResultsParser {
   }
 
   async parseFromJsonFile(filePath: string) {
-    const data = fs.readFileSync(filePath, 'utf-8');
-    const parsedData: JSONResult = JSON.parse(data);
+    let data: string;
+    let parsedData: JSONResult;
+    try {
+      data = fs.readFileSync(filePath, 'utf-8');
+      parsedData = JSON.parse(data);
+    } catch (error) {
+      throw new Error(
+        `Error reading or parsing JSON file [${filePath}]: \n\t${error}`,
+      );
+    }
 
     const retries = parsedData.config.projects[0]?.retries || 0;
     for (const suite of parsedData.suites) {

--- a/src/SlackReporter.ts
+++ b/src/SlackReporter.ts
@@ -111,6 +111,18 @@ class SlackReporter implements Reporter {
       return;
     }
 
+    if (
+      resultSummary.passed === 0
+      && resultSummary.failed === 0
+      && resultSummary.flaky === 0
+      && resultSummary.skipped === 0
+      && resultSummary.failures.length === 0
+      && resultSummary.tests.length === 0
+    ) {
+      this.log('⏩ Slack reporter - Playwright reported : "No tests found"');
+      return;
+    }
+
     const agent = this.proxy ? new HttpsProxyAgent(this.proxy) : undefined;
 
     if (this.slackWebHookUrl) {

--- a/tests/ResultsParser.spec.ts
+++ b/tests/ResultsParser.spec.ts
@@ -528,6 +528,20 @@ test.describe('ResultsParser', () => {
     expect(resultSummary.tests.length).toEqual(10);
   });
 
+  test('throw an error when the results file is not a valid json', async ({}) => {
+    const resultsParser = new ResultsParser();
+    const validTestResults = path.join(
+      __dirname,
+      'test_data',
+      'invalid_json_results.json',
+    );
+    try {
+      await resultsParser.parseFromJsonFile(validTestResults);
+    } catch (error) {
+      expect(error.toString()).toContain('Error: Error reading or parsing JSON file');
+    }
+  });
+
   test('parse test results from a complicated json file', async ({}) => {
     const resultsParser = new ResultsParser();
     const validTestResults = path.join(


### PR DESCRIPTION
**Description:**

* Suppress reporting when no tests run
* Added better error handling when parsing results from JSON file

**Related issue:**

https://github.com/ryanrosello-og/playwright-slack-report/issues/137


**Check list:**
- [N] Mark if documentation changes are required.
- [Y] Mark if tests were added or updated to cover the changes.