### PR TITLE
Updated logic for when the resultSummary gets set and updated

### DIFF
--- a/src/ResultsParser.ts
+++ b/src/ResultsParser.ts
@@ -211,7 +211,23 @@ export default class ResultsParser {
 
   updateResults(data: { testSuite: any }) {
     if (data.testSuite.tests.length > 0) {
-      this.result.push(data);
+      const resIndex = this.result.findIndex(
+        (res) => res.testSuite.title === data.testSuite.title,
+      );
+      if (resIndex > -1) {
+        for (const test of data.testSuite.tests) {
+          const testIndex = this.result[resIndex].testSuite.tests.findIndex(
+            (tes) => tes.name === test.name,
+          );
+          if (testIndex > -1) {
+            this.result[resIndex].testSuite.tests[testIndex] = test;
+          } else {
+            this.result[resIndex].testSuite.tests.push(test);
+          }
+        }
+      } else {
+        this.result.push(data);
+      }
     }
   }
 


### PR DESCRIPTION
Noticed when using the reporter, that if the tests retry, the Results object would be erroneously populated. Refer to the below screenshot. In this example, there are 5 legitimate tests, with one of them retrying 5 times after failing, as you can see, the results array is getting pushed to each time, regardless if that result already exists. Further more, this is made even worse as each time the results array gets pushed to, the current testSuite state also gets pushed.

So instead of there being 1 test suite, 5 result getting pushed, there is the same test suite 5x being pushed

![image](https://github.com/user-attachments/assets/0d40a5fb-47a6-4317-a458-8b7ad2516b8d)


I decide to iterate over the existing results and then push to the array if the result does not exist, and modify the result if it does. 

Note; a caveat to this implementation is that for failed tests, only the last instance of it failing will be in the results array

![image](https://github.com/user-attachments/assets/5daf4a3e-1a2d-4c4f-b915-5325d36a152a)

This saves having to do filtering later on, but I can update the logic slightly to push each time for test retries rather than replace

