### PR TITLE
Don't show "There are too many failures to display" if maxNumberOfFai…

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@playwright/test": "^1.46.1",
     "@slack/types": "^2.14.0",
     "@playwright/test": "^1.47.0",
     "@typescript-eslint/eslint-plugin": "^5.30.6",
@@ -36,7 +35,7 @@
     "cli-debug": "yarn build && npx . -c ./cli_config.json -j ./tests/test_data/valid_test_results.json"
   },
   "name": "playwright-slack-report",
-  "version": "1.1.86",
+  "version": "1.1.88",
   "bin": {
     "playwright-slack-report": "dist/cli.js"
   },

--- a/src/LayoutGenerator.ts
+++ b/src/LayoutGenerator.ts
@@ -72,7 +72,7 @@ const generateFailures = async (
     });
   }
 
-  if (summaryResults.failures.length > maxNumberOfFailures) {
+  if (maxNumberOfFailures > 0 && summaryResults.failures.length > maxNumberOfFailures) {
     fails.push({
       type: 'section',
       text: {
@@ -81,6 +81,11 @@ const generateFailures = async (
       },
     });
   }
+
+  if (fails.length === 0) {
+    return [];
+  }
+
   return [
     {
       type: 'divider',

--- a/src/SlackClient.ts
+++ b/src/SlackClient.ts
@@ -126,6 +126,10 @@ export default class SlackClient {
   }) {
     const result = [];
     const blocks = await generateFailures(summaryResults, maxNumberOfFailures);
+    if (blocks.length === 0) {
+      return result;
+    }
+
     const fallbackText = generateFallbackText(summaryResults);
     for (const channel of channelIds) {
       // under test

--- a/tests/SlackClient_generate_blocks.spec.ts
+++ b/tests/SlackClient_generate_blocks.spec.ts
@@ -172,9 +172,6 @@ test.describe('SlackClient.generateBlocks()', () => {
           text: '\n*BuildID* :\t9sdcv-312432-3134',
         },
       },
-      {
-        type: 'divider',
-      },
     ]);
   });
 
@@ -223,9 +220,6 @@ test.describe('SlackClient.generateBlocks()', () => {
           type: 'mrkdwn',
           text: '✅ *0* | ❌ *1* | ⏩ *1*',
         },
-      },
-      {
-        type: 'divider',
       },
     ]);
   });


### PR DESCRIPTION
**Description:**

Suppress the "There are too many failures to display" message if maxNumberOfFailures is zero


**Related issue:**
https://github.com/ryanrosello-og/playwright-slack-report/issues/187


**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.