### PR TITLE
chore: update permissions to write in publish workflow and bump versi…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,6 @@
 name: Node.js Package and Publish
 permissions:
-  contents: read
+  contents: write
 on:
   release:
     types: [created]

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "cli-debug": "yarn build && npx . -c ./cli_config.json -j ./tests/test_data/valid_test_results.json"
   },
   "name": "playwright-slack-report",
-  "version": "1.1.90",
+  "version": "1.1.91",
   "bin": {
     "playwright-slack-report": "dist/cli.js"
   },


### PR DESCRIPTION
…on to 1.1.91

**Description:**

Update publish workflow permission to allow publishing.


**Related issue:**

[Publish 1.1.90 to npm](https://github.com/ryanrosello-og/playwright-slack-report/issues/251)



**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.