### PR TITLE
chore: update workflow to use ubuntu-latest and bump version to 1.1.92

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - name: install node v18.18.2

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "cli-debug": "yarn build && npx . -c ./cli_config.json -j ./tests/test_data/valid_test_results.json"
   },
   "name": "playwright-slack-report",
-  "version": "1.1.91",
+  "version": "1.1.92",
   "bin": {
     "playwright-slack-report": "dist/cli.js"
   },


### PR DESCRIPTION
**Description:**

Fix for this gh action error:

```
[publish](https://github.com/ryanrosello-og/playwright-slack-report/actions/runs/14684464007/job/41211290258)
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```


**Related issue:**



**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.