### PR TITLE
feat: add sendCustomBlocksInThreadAfterIndex to allow custom layouts to access threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,12 @@ Instructs the reporter to show the failure details in a thread instead of the ma
 
 ![Show failures in threads](./assets/threads.png)
 
+### **sendCustomBlocksInThreadAfterIndex** (default: undefined)
+
+Instructs the reporter to send blocks provided by your [custom layout](#-define-your-own-slack-message-custom-layout) to in the thread following the index specified. _Example_:
+
+`sendCustomBlocksInThreadAfterIndex: 3`
+
 ### **proxy** (optional)
 
 String representation of your proxy server.

--- a/cli.ts
+++ b/cli.ts
@@ -131,6 +131,7 @@ async function sendResultsUsingBot({
         disableUnfurl: config.disableUnfurl,
         summaryResults,
         showInThread: config.showInThread,
+        sendCustomBlocksInThreadAfterIndex: config.sendCustomBlocksInThreadAfterIndex,
       },
     });
 

--- a/src/SlackReporter.ts
+++ b/src/SlackReporter.ts
@@ -23,6 +23,8 @@ class SlackReporter implements Reporter {
 
   private showInThread: boolean;
 
+  private sendCustomBlocksInThreadAfterIndex?: number;
+
   private meta: Array<{ key: string; value: string }> = [];
 
   private resultsParser: ResultsParser;
@@ -86,6 +88,10 @@ class SlackReporter implements Reporter {
         = slackReporterConfig.slackWebHookChannel || undefined;
       this.disableUnfurl = slackReporterConfig.disableUnfurl || false;
       this.showInThread = slackReporterConfig.showInThread || false;
+      if (slackReporterConfig.sendCustomBlocksInThreadAfterIndex) {
+        this.sendCustomBlocksInThreadAfterIndex
+          = slackReporterConfig.sendCustomBlocksInThreadAfterIndex;
+      }
       this.slackLogLevel = slackReporterConfig.slackLogLevel || LogLevel.DEBUG;
       this.proxy = slackReporterConfig.proxy || undefined;
     }
@@ -168,6 +174,7 @@ class SlackReporter implements Reporter {
           disableUnfurl: this.disableUnfurl,
           summaryResults: resultSummary,
           showInThread: this.showInThread,
+          sendCustomBlocksInThreadAfterIndex: this.sendCustomBlocksInThreadAfterIndex,
         },
       });
       // eslint-disable-next-line no-console

--- a/src/cli/cli_pre_checks.ts
+++ b/src/cli/cli_pre_checks.ts
@@ -70,6 +70,14 @@ export const doPreChecks = async (
     };
   }
 
+  if (config.sendUsingWebhook && config.sendCustomBlocksInThreadAfterIndex) {
+    return {
+      status: 'error',
+      message:
+        'The sendCustomBlocksInThreadAfterIndex feature is only supported when using sendUsingBot is configured',
+    };
+  }
+
   if (!config.sendUsingWebhook && !config.sendUsingBot) {
     return {
       status: 'error',

--- a/src/cli/cli_schema.ts
+++ b/src/cli/cli_schema.ts
@@ -32,6 +32,7 @@ export const ZodCliSchema = z.object({
   showInThread: z.boolean().default(false),
   proxy: z.string().url().optional(),
   meta: z.array(z.object({ key: z.string(), value: z.string() })).optional(),
+  sendCustomBlocksInThreadAfterIndex: z.number().optional(),
 });
 
 export interface ICliConfig {
@@ -56,4 +57,5 @@ export interface ICliConfig {
   showInThread: boolean;
   proxy?: string;
   meta?: Array<{ key: string; value: string }>;
+  sendCustomBlocksInThreadAfterIndex?: number;
 }

--- a/tests/SlackClient_send_message.spec.ts
+++ b/tests/SlackClient_send_message.spec.ts
@@ -111,6 +111,80 @@ test.describe('SlackClient.sendMessage()', () => {
     ]);
   });
 
+  test('sends custom blocks in one message when sendCustomBlocksInThreadAfterIndex is not set', async ({
+    testSlackClient,
+    testSummaryAllTestsFailed,
+  }) => {
+    let fakeRequestCallCounter = 0;
+
+    const fakeRequest = async (): Promise<ChatPostMessageResponse> => {
+      fakeRequestCallCounter += 1;
+      return {
+        ok: true,
+      };
+    };
+
+    const channelId = 'C12345';
+    const clientResponse = await testSlackClient.sendMessage({
+      options: {
+        channelIds: [channelId],
+        summaryResults: testSummaryAllTestsFailed,
+        customLayout: generateCustomLayout,
+        customLayoutAsync: undefined,
+        fakeRequest,
+        maxNumberOfFailures: 10,
+        showInThread: false,
+        sendCustomBlocksInThreadAfterIndex: undefined,
+      },
+    });
+
+    expect(fakeRequestCallCounter).toBe(1);
+
+    expect(clientResponse).toEqual([
+      {
+        channel: channelId,
+        outcome: '✅ Message sent to C12345',
+      },
+    ]);
+  });
+
+  test('sends custom blocks in thread when sendCustomBlocksInThreadAfterIndex is set', async ({
+    testSlackClient,
+    testSummaryAllTestsFailed,
+  }) => {
+    let fakeRequestCallCounter = 0;
+
+    const fakeRequest = async (): Promise<ChatPostMessageResponse> => {
+      fakeRequestCallCounter += 1;
+      return {
+        ok: true,
+      };
+    };
+
+    const channelId = 'C12345';
+    const clientResponse = await testSlackClient.sendMessage({
+      options: {
+        channelIds: [channelId],
+        summaryResults: testSummaryAllTestsFailed,
+        customLayout: generateCustomLayout,
+        customLayoutAsync: undefined,
+        fakeRequest,
+        maxNumberOfFailures: 10,
+        showInThread: false,
+        sendCustomBlocksInThreadAfterIndex: 1,
+      },
+    });
+
+    expect(fakeRequestCallCounter).toBe(6);
+
+    expect(clientResponse).toEqual([
+      {
+        channel: channelId,
+        outcome: '✅ Message sent to C12345',
+      },
+    ]);
+  });
+
   test('provides an error when posting message to Slack fails', async ({
     testSlackClient,
     testSummaryAllTestsPassed,

--- a/tests/cli_prechecks.spec.ts
+++ b/tests/cli_prechecks.spec.ts
@@ -64,6 +64,19 @@ test.describe('CLI app - pre-check', () => {
     );
   });
 
+  test('throws an error when both sendUsingWebhook and sendCustomBlocksInThreadAfterIndex are truthy', async ({}) => {
+    const invalidConfig = path.join(
+      __dirname,
+      'test_data',
+      'invalid_cli_config_sendCustomBlocksInThreadAfterIndex_enable_for_webhook.json',
+    );
+    const result = await doPreChecks(validTestResults, invalidConfig);
+    expect(result.status).toEqual('error');
+    expect(result.message).toContain(
+      'The sendCustomBlocksInThreadAfterIndex feature is only supported when using sendUsingBot is configured',
+    );
+  });
+
   test('throws an error when missing both sendUsingBot and sendUsingWebhook keys', async ({}) => {
     const invalidConfig = path.join(
       __dirname,

--- a/tests/test_data/invalid_cli_config_sendCustomBlocksInThreadAfterIndex_enable_for_webhook.json
+++ b/tests/test_data/invalid_cli_config_sendCustomBlocksInThreadAfterIndex_enable_for_webhook.json
@@ -1,0 +1,17 @@
+{
+  "sendResults": "always",
+  "slackLogLevel": "error",
+  "showInThread": false,
+  "sendCustomBlocksInThreadAfterIndex": 1,
+  "meta": [
+    { "key": "build", "value" : "1.0.0"},
+    { "key": "branch", "value" : "master"},
+    { "key": "commit", "value" : "1234567890"},
+    { "key": "results", "value" : "https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png"}
+  ],
+  "maxNumberOfFailures": 1,
+  "disableUnfurl": true,
+  "sendUsingWebhook": {
+    "webhookUrl":"https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"
+  }
+}


### PR DESCRIPTION
**Description:**
Custom layouts should have access to send messages in threads. This change adds a new `sendCustomBlocksInThreadAfterIndex` configuration option that simply `slice`s the blocks returned by the custom layout generator to send follow-up messages in threads.

Deciding to send each block as a distinct follow-up message was an intentional choice, it allows for smaller message bodies that are easier to chain other automations off of.


**Related issue:**
Add link to the related issue.


**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.