### PR TITLE
BUG: CLI - Flaky tests are considered as failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ playwright-report/
 tests/this.spec.ts
 bag.json
 bag2.json
+
+# Intellij Idea Code files
+.idea

--- a/cli.ts
+++ b/cli.ts
@@ -42,6 +42,12 @@ program
     const resultSummary = await resultsParser.parseFromJsonFile(
       preCheckResult.jsonPath!,
     );
+
+    if (config.sendResults === 'on-failure' && resultSummary.failed === 0) {
+      console.log('⏩ Slack CLI reporter - no failures found');
+      process.exit(0);
+    }
+
     if (config.sendUsingBot) {
       const slackClient = new SlackClient(
         new WebClient(process.env.SLACK_BOT_USER_OAUTH_TOKEN, {
@@ -104,13 +110,6 @@ async function sendResultsUsingBot({
 }): Promise<boolean> {
   if (config.slackLogLevel === LogLevel.DEBUG) {
     console.log({ config });
-  }
-  if (
-    resultSummary.failures.length === 0
-    && config.sendResults === 'on-failure'
-  ) {
-    console.log('⏩ Slack CLI reporter - no failures found');
-    return true;
   }
   let summaryResults = resultSummary;
   const meta = replaceEnvVars(config.meta);


### PR DESCRIPTION
**Description:**
CLI - if tests are flaky and overall tests passed, then the test run should not be considered as failure. Changes made to handle this.
Add IntelliJ idea files to gitignore

**Related issue:**
[Issue](https://github.com/ryanrosello-og/playwright-slack-report/issues/271)

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.