### PR TITLE
Update Node.js version in publish workflow to 22

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: install node v18.18.2
+      - name: install node v22
         uses: actions/setup-node@v1
         with:
-          node-version: 18.18.2
+          node-version: 22
       - name: yarn install
         run: yarn install
       - name: build


### PR DESCRIPTION
**Description:**

Fix failing publish gh action due to old node version


**Related issue:**
Add link to the related issue.


**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.