### PR TITLE
combine threaded messages into a single message

### DIFF
--- a/src/SlackClient.ts
+++ b/src/SlackClient.ts
@@ -130,28 +130,26 @@ export default class SlackClient {
     if (threadedBlocks.length > 0) {
       for (let i = 0; i < result.length; i += 1) {
         const threadTs = result[i].ts;
-        for (const block of threadedBlocks) {
-          try {
-            if (options.fakeRequest) {
-              await options.fakeRequest();
-            } else {
-              await SlackClient.doPostRequest(
-                this.slackWebClient,
-                result[i].channel,
-                fallbackText,
-                [block],
-                unfurl,
-                threadTs,
-              );
-            }
-            // eslint-disable-next-line no-console
-            console.log(`✅ Threaded message sent to ${result[i].channel}`);
-          } catch (error: any) {
-            // eslint-disable-next-line no-console
-            console.error(
-              `❌ Failed to send threaded message to ${result[i].channel}: ${error.message}`,
+        try {
+          if (options.fakeRequest) {
+            await options.fakeRequest();
+          } else {
+            await SlackClient.doPostRequest(
+              this.slackWebClient,
+              result[i].channel,
+              fallbackText,
+              threadedBlocks,
+              unfurl,
+              threadTs,
             );
           }
+          // eslint-disable-next-line no-console
+          console.log(`✅ Threaded message sent to ${result[i].channel}`);
+        } catch (error: any) {
+          // eslint-disable-next-line no-console
+          console.error(
+            `❌ Failed to send threaded message to ${result[i].channel}: ${error.message}`,
+          );
         }
       }
     }

--- a/tests/SlackClient_send_message.spec.ts
+++ b/tests/SlackClient_send_message.spec.ts
@@ -175,7 +175,7 @@ test.describe('SlackClient.sendMessage()', () => {
       },
     });
 
-    expect(fakeRequestCallCounter).toBe(6);
+    expect(fakeRequestCallCounter).toBe(2);
 
     expect(clientResponse).toEqual([
       {


### PR DESCRIPTION
**Description:**
Follow up to https://github.com/ryanrosello-og/playwright-slack-report/pull/259, this combines the blocks sent in separate messages inside the thread in separate messages. This was an intentional design choice at first but it has ended up causing more problems than it has solved, and this is a better solution when considering Slack API rate limits

**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.