### PR TITLE
Fix CLI mode incorrectly sending flaky test details to Slack threads

### DIFF
--- a/src/ResultsParser.ts
+++ b/src/ResultsParser.ts
@@ -110,6 +110,11 @@ export default class ResultsParser {
     for (const spec of specs) {
       for (const test of spec.tests) {
         const { expectedStatus } = test;
+        // Calculate actual retries based on the maximum retry attempt for this test
+        const maxRetryAttempt = test.results.length > 0
+          ? Math.max(...test.results.map((r: any) => r.retry))
+          : 0;
+        const effectiveRetries = Math.max(maxRetryAttempt, retries);
         for (const result of test.results) {
           testResults.push({
             suiteName,
@@ -118,7 +123,7 @@ export default class ResultsParser {
             browser: test.projectName,
             projectName: test.projectName,
             retry: result.retry,
-            retries,
+            retries: effectiveRetries,
             startedAt: result.startTime,
             endedAt: new Date(
               new Date(result.startTime).getTime() + result.duration,

--- a/tests/CLI_RetryThreading.spec.ts
+++ b/tests/CLI_RetryThreading.spec.ts
@@ -1,0 +1,190 @@
+import { expect, test } from '@playwright/test';
+import ResultsParser from '../src/ResultsParser';
+
+test.describe('CLI Mode Retry Threading Fix', () => {
+  test('parseTests calculates effective retries correctly for CLI mode flaky tests', async () => {
+    const resultsParser = new ResultsParser();
+
+    // Test data representing a flaky test (failed on retry 0, passed on retry 1)
+    const mockSpecs = [
+      {
+        title: 'Flaky Test',
+        tests: [
+          {
+            projectName: 'chrome',
+            results: [
+              {
+                retry: 0,
+                status: 'failed',
+                duration: 1000,
+                startTime: '2023-01-01T00:00:00.000Z',
+                error: {
+                  snippet: 'Flaky test failed on first attempt',
+                  stack: 'Error: Assertion failed\n    at test.js:10:5',
+                },
+              },
+              {
+                retry: 1,
+                status: 'passed',
+                duration: 1000,
+                startTime: '2023-01-01T00:00:01.000Z',
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    // Parse with global retries = 1 (simulating CLI mode)
+    const testResults = await resultsParser.parseTests('Test Suite', mockSpecs, 1);
+
+    // Verify effective retries are calculated correctly
+    expect(testResults).toHaveLength(2);
+
+    // Failed attempt should have effective retries = 1 (max of actual retry 1, global 1)
+    const failedResult = testResults.find((r) => r.retry === 0);
+    expect(failedResult).toBeDefined();
+    expect(failedResult!.retries).toBe(1);
+    expect(failedResult!.status).toBe('failed');
+
+    // Passed attempt should also have effective retries = 1
+    const passedResult = testResults.find((r) => r.retry === 1);
+    expect(passedResult).toBeDefined();
+    expect(passedResult!.retries).toBe(1);
+    expect(passedResult!.status).toBe('passed');
+
+    // Now test the integration with parseTestSuite to verify getFailures behavior
+    await resultsParser.parseTestSuite({
+      title: 'Test Suite',
+      specs: mockSpecs,
+    }, 1);
+
+    const failures = await resultsParser.getFailures();
+
+    // Flaky test failure should be excluded because retry (0) !== retries (1)
+    const flakyFailure = failures.find((f) => f.test === 'Flaky Test');
+    expect(flakyFailure).toBeUndefined();
+  });
+
+  test('parseTests identifies test that failed on final retry', async () => {
+    const resultsParser = new ResultsParser();
+
+    // Test data representing a test that failed on its final retry
+    const mockSpecs = [
+      {
+        title: 'Eventually Failed Test',
+        tests: [
+          {
+            projectName: 'chrome',
+            results: [
+              {
+                retry: 0,
+                status: 'failed',
+                duration: 1000,
+                startTime: '2023-01-01T00:00:00.000Z',
+                error: {
+                  snippet: 'First failure',
+                  stack: 'Error: First failure',
+                },
+              },
+              {
+                retry: 1,
+                status: 'failed',
+                duration: 1000,
+                startTime: '2023-01-01T00:00:01.000Z',
+                error: {
+                  snippet: 'Final failure',
+                  stack: 'Error: Final failure',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    await resultsParser.parseTestSuite({
+      title: 'Retry Suite',
+      specs: mockSpecs,
+    }, 1);
+    const failures = await resultsParser.getFailures();
+
+    // Should include the test that failed on its final retry (retry 1, retries = 1)
+    expect(failures).toHaveLength(1);
+    expect(failures[0].test).toBe('Eventually Failed Test [chrome]');
+    expect(failures[0].suite).toBe('Retry Suite');
+    expect(failures[0].failureReason).toContain('Final failure');
+  });
+
+  test('parseTests uses global retries when higher than actual retries', async () => {
+    const resultsParser = new ResultsParser();
+
+    // Test data with global retries higher than actual attempts
+    const mockSpecs = [
+      {
+        title: 'Test That Passed First Try',
+        tests: [
+          {
+            projectName: 'chrome',
+            results: [
+              {
+                retry: 0,
+                status: 'passed',
+                duration: 1000,
+                startTime: '2023-01-01T00:00:00.000Z',
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const testResults = await resultsParser.parseTests('Test Suite', mockSpecs, 3);
+
+    // Should use global retries (3) since it's higher than max retry attempt (0)
+    expect(testResults).toHaveLength(1);
+    expect(testResults[0].retries).toBe(3);
+    expect(testResults[0].retry).toBe(0);
+    expect(testResults[0].status).toBe('passed');
+
+    // Test with parseTestSuite to verify getFailures behavior
+    await resultsParser.parseTestSuite({
+      title: 'Test Suite',
+      specs: mockSpecs,
+    }, 3);
+
+    // Verify no failures (test passed)
+    const failures = await resultsParser.getFailures();
+    expect(failures).toHaveLength(0);
+  });
+
+  test('parseTests handles empty results array gracefully', async () => {
+    const resultsParser = new ResultsParser();
+
+    // Test data with empty results array
+    const mockSpecs = [
+      {
+        title: 'Test With No Results',
+        tests: [
+          {
+            projectName: 'chrome',
+            results: [], // Empty results array
+          },
+        ],
+      },
+    ];
+
+    // This should not throw an error and should handle empty results gracefully
+    const testResults = await resultsParser.parseTests('Test Suite', mockSpecs, 1);
+    expect(testResults).toHaveLength(0); // No test results should be created
+
+    // Test with parseTestSuite as well
+    await resultsParser.parseTestSuite({
+      title: 'Test Suite',
+      specs: mockSpecs,
+    }, 1);
+
+    const failures = await resultsParser.getFailures();
+    expect(failures).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
**Description:**
This pull request introduces enhancements to the `ResultsParser` class to improve handling of retry logic for test results, particularly in CLI mode. It also adds comprehensive tests to validate these changes, ensuring accurate calculation of effective retries and proper exclusion of flaky tests from failure reports.

### Enhancements to `ResultsParser` retry logic:

* **Effective Retry Calculation**: Added logic to calculate `effectiveRetries` based on the maximum retry attempt for each test, ensuring accurate representation of retries in CLI mode. (`src/ResultsParser.ts`, [[1]](diffhunk://#diff-dd35350d04471d6e992caf9884d23402efe54f32db820611e06b0d1e3930778dR113-R117) [[2]](diffhunk://#diff-dd35350d04471d6e992caf9884d23402efe54f32db820611e06b0d1e3930778dL121-R126)

### Comprehensive testing for retry logic:

* **New Test Suite**: Introduced `CLI_RetryThreading.spec.ts`, which includes multiple test cases to validate retry logic, flaky test exclusion, and handling of edge cases like empty results arrays. (`tests/CLI_RetryThreading.spec.ts`, [tests/CLI_RetryThreading.spec.tsR1-R190](diffhunk://#diff-772e672a38ada81efc41dd93e501dbcd569b8c27f15fba93fd92717a4f62707aR1-R190))
* **Additional Tests**: Expanded `ResultsParser.spec.ts` with specific test cases to verify retry calculations, global retries behavior, and correct handling of flaky and permanently failed tests. (`tests/ResultsParser.spec.ts`, [tests/ResultsParser.spec.tsR577-R945](diffhunk://#diff-846b577eb5e0d5f5a90d4a349a384dc5edcd37ecaa30a21d58a95abe0192a339R577-R945))


**Related issue:**
- https://github.com/ryanrosello-og/playwright-slack-report/issues/297


**Check list:**
- [x] Mark if documentation changes are required.
- [x] Mark if tests were added or updated to cover the changes.