### PR TITLE
fix: repair behavior when sending more than 50 blocks

### DIFF
--- a/tests/SlackClient_send_message.spec.ts
+++ b/tests/SlackClient_send_message.spec.ts
@@ -185,6 +185,74 @@ test.describe('SlackClient.sendMessage()', () => {
     ]);
   });
 
+  test('sends custom blocks in multiple threaded messages when more than 50 blocks', async ({
+    testSlackClient,
+    testSummaryAllTestsFailed,
+  }) => {
+    let fakeRequestCallCounter = 0;
+
+    const fakeRequest = async (): Promise<ChatPostMessageResponse> => {
+      fakeRequestCallCounter += 1;
+      return {
+        ok: true,
+        ts: '1684631671.947369',
+      };
+    };
+
+    // Create a layout that generates more than 50 blocks for the threaded portion
+    const generateManyThreadedBlocks = () => {
+      const blocks: any[] = [];
+
+      // First block (will be in main message)
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: '*Main Message Block*',
+        },
+      });
+
+      // Generate 51 blocks for the threaded portion (more than 50 limit)
+      for (let i = 0; i < 51; i += 1) {
+        blocks.push({
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: `*Threaded Block ${i + 1}*\nThis is threaded block number ${i + 1} of 51`,
+          },
+        });
+      }
+
+      return blocks;
+    };
+
+    const channelId = 'C12345';
+    const clientResponse = await testSlackClient.sendMessage({
+      options: {
+        channelIds: [channelId],
+        summaryResults: testSummaryAllTestsFailed,
+        customLayout: generateManyThreadedBlocks,
+        customLayoutAsync: undefined,
+        fakeRequest,
+        maxNumberOfFailures: 10,
+        showInThread: false,
+        sendCustomBlocksInThreadAfterIndex: 1, // Only first block in main message, rest in thread
+      },
+    });
+
+    // Should make 3 calls: 1 for main message (1 block), 2 for threaded messages
+    // (52 blocks split into 2 chunks of 50 and 2)
+    expect(fakeRequestCallCounter).toBe(3);
+
+    expect(clientResponse).toEqual([
+      {
+        channel: channelId,
+        outcome: '✅ Message sent to C12345',
+        ts: '1684631671.947369',
+      },
+    ]);
+  });
+
   test('provides an error when posting message to Slack fails', async ({
     testSlackClient,
     testSummaryAllTestsPassed,


### PR DESCRIPTION
**Description:**
Through trial and error, we've discovered that there is a 50 block limit to Slack messages. This PR adds the appropriate handling to split messages with more than 50 blocks up into multiple messages.