### PR TITLE
fix Error in reporter RangeError: Invalid string length

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "cli-debug": "yarn build && npx . -c ./cli_config.json -j ./tests/test_data/valid_test_results.json"
   },
   "name": "playwright-slack-report",
-  "version": "1.1.99",
+  "version": "1.1.100",
   "bin": {
     "playwright-slack-report": "dist/cli.js"
   },

--- a/src/SlackClient.ts
+++ b/src/SlackClient.ts
@@ -80,8 +80,10 @@ export default class SlackClient {
         blocks = allBlocks;
       }
     } else if (options.showInThread) {
-      const modifiedOptions = JSON.parse(JSON.stringify(options));
-      modifiedOptions.summaryResults.failures = [];
+      const modifiedOptions = {
+        ...options,
+        summaryResults: { ...options.summaryResults, failures: [] },
+      };
       blocks = await generateBlocks(
         modifiedOptions.summaryResults,
         options.maxNumberOfFailures,


### PR DESCRIPTION

**Description:**

This pull request contains a version bump and a small code improvement for creating modified options in the `SlackClient`. The main change is a refactor to use object spread syntax instead of deep cloning with `JSON.parse(JSON.stringify(...))` when clearing failures in the summary results.

Code improvement:

* Refactored the way `modifiedOptions` is created in `SlackClient` to use object spread syntax for clearing `failures`, making the code more concise and efficient.

Other:

* Bumped the package version from `1.1.99` to `1.1.100` in `package.json`.

**Related issue:**
[Add link to the related issue.](https://github.com/ryanrosello-og/playwright-slack-report/issues/317)


**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.