### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/ryanrosello-og/playwright-slack-report.git"
+    "url": "git+https://github.com/ryanrosello-og/playwright-slack-report.git"
   },
   "author": "Ryan Rosello <ryanrosello@hotmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- replace the SSH-only repository URL with a public HTTPS Git URL
- keep npm repository metadata usable without GitHub SSH credentials

## Verification
- TypeScript build (`tsc -p ./tsconfig.json`)
- ESLint (`eslint src`)
- `pnpm pack --dry-run --json`
- direct package metadata assertion
- `git diff --check`